### PR TITLE
Refactor ConfigPane into responsive TopConfigBar and SidebarConfig

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,7 +132,8 @@ Balances are computed per **ferieår** (vacation year). Ferieår N runs Sep 1 Ye
 
 ## Key Behaviors
 
-- The top config bar ("Optjente feriedage" + "Fra dato") is always visible at the top of the page above the explanatory text, in a horizontal layout with `max-w-lg` to prevent inputs from stretching too wide. Order: vacation days first, start date second. Labels wrap if needed.
+- The top config bar ("Optjente feriedage" + "Fra dato") is always visible at the top of the page above the explanatory text, in a horizontal layout with `max-w-lg` centered (`mx-auto`) to prevent inputs from stretching too wide. Order: vacation days first, start date second. Labels wrap if needed.
+- Vertical spacing between settings button, config inputs, help text, and calendar uses a uniform `gap-4` (16px) on the parent flex-col, with `pt-4` for top padding. The settings button uses `mb-4` to match.
 - On desktop (lg+): the sidebar config cards (Indstillinger, Helligdage, Data) are always visible in the left sidebar. Config cards are not collapsible.
 - On mobile: a circular settings icon button (lucide-react `Settings`) appears above the top config bar inputs. Clicking it opens a slide-in drawer from the left containing the sidebar config cards, overlaid on a semi-dark backdrop (`bg-black/50`). Body scroll is locked when the drawer is open (`overflow: hidden` on body + `overscroll-contain` on drawer panel). Drawer auto-closes when resizing to desktop. Clicking the overlay closes the drawer.
 - Each config field in the settings card has a `HelpIcon` (CircleHelp from lucide-react) placed to the right of the input element. Click opens a Popover with a Danish description; click outside dismisses (touch-friendly, no hover required).
@@ -141,7 +142,7 @@ Balances are computed per **ferieår** (vacation year). Ferieår N runs Sep 1 Ye
 - Year separators appear after December months spanning the full grid width with three states: (1) "Ingen feriedage overføres til næste ferieår" if balance is 0, (2) "X.XX feriedage overføres til næste ferieår" if within transfer limit, (3) "X.XX feriedage overføres til næste ferieår, Y.YY feriedage overføres ikke" if exceeding limit (Y.YY in bold red). All text is gray except the lost amount.
 - Holidays in config pane show date tooltip on hover and highlight the corresponding calendar day with a blue ring
 - Holidays are grouped by year in an accordion, filtered to only show years visible in the calendar
-- Calendar view has `max-w-5xl` to prevent stretching on wide monitors
+- Calendar view has `max-w-6xl` to prevent stretching on wide monitors
 - Visible years are derived automatically from `state.holidays` (unique years from holiday dates, always including current year). The calendar displays all years that have holidays configured. `visibleYears` is computed in VacationContext and exposed via context.
 - State survives page refresh via localStorage
 - `holidayNames` map is derived from `state.holidays` for holiday name lookups

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,9 +132,9 @@ Balances are computed per **ferieår** (vacation year). Ferieår N runs Sep 1 Ye
 
 ## Key Behaviors
 
-- The top config bar (start date + initial vacation days) is always visible at the top of the page above the explanatory text, in a horizontal layout. The label "Optjente feriedage ved startdato" wraps if needed.
+- The top config bar ("Optjente feriedage" + "Fra dato") is always visible at the top of the page above the explanatory text, in a horizontal layout with `max-w-lg` to prevent inputs from stretching too wide. Order: vacation days first, start date second. Labels wrap if needed.
 - On desktop (lg+): the sidebar config cards (Indstillinger, Helligdage, Data) are always visible in the left sidebar. Config cards are not collapsible.
-- On mobile: a circular settings icon button (lucide-react `Settings`) appears to the left of the top config bar. Clicking it opens a slide-in drawer from the left containing the sidebar config cards, overlaid on a semi-dark backdrop (`bg-black/50`). Body scroll is locked when the drawer is open (`overflow: hidden` on body + `overscroll-contain` on drawer panel). Drawer auto-closes when resizing to desktop. Clicking the overlay closes the drawer.
+- On mobile: a circular settings icon button (lucide-react `Settings`) appears above the top config bar inputs. Clicking it opens a slide-in drawer from the left containing the sidebar config cards, overlaid on a semi-dark backdrop (`bg-black/50`). Body scroll is locked when the drawer is open (`overflow: hidden` on body + `overscroll-contain` on drawer panel). Drawer auto-closes when resizing to desktop. Clicking the overlay closes the drawer.
 - Each config field in the settings card has a `HelpIcon` (CircleHelp from lucide-react) placed to the right of the input element. Click opens a Popover with a Danish description; click outside dismisses (touch-friendly, no hover required).
 - Dates before `startDate` are disabled and not selectable (status `before-start`)
 - Month headers show ferieår balances with format "YY/(YY+1): X.XX" (e.g., "25/26: 3.40"). Year label is gray, balance is green. For months Jan-Aug only the active ferieår is shown on the left. For Sep-Dec both ferieår are shown (ending year on left, new year on right).
@@ -154,7 +154,7 @@ Balances are computed per **ferieår** (vacation year). Ferieår N runs Sep 1 Ye
 - Context functions (`toggleDate`, `toggleHoliday`, `initDefaults`, `addHoliday`, `resetState`) have stable references (React Compiler handles this automatically)
 - Current year accordion is expanded by default; other years are collapsed
 - Users can add custom holidays via a "Tilføj helligdag" button (opens Popover with name field and native date picker) at the top of the Helligdage card content
-- Number inputs (Optjente feriedage ved startdato, Ekstra feriedage, Forskudsferie) use `DeferredNumberInput` — local state while typing, commits to global state on blur/Enter. This avoids recomputing `dayStatuses` on every keystroke. All are clamped to 0–99.
+- Number inputs (Optjente feriedage, Ekstra feriedage, Forskudsferie) use `DeferredNumberInput` — local state while typing, commits to global state on blur/Enter. This avoids recomputing `dayStatuses` on every keystroke. All are clamped to 0–99.
 - Drawer animations (`drawer-slide-in`, `drawer-overlay-in`) are defined as CSS keyframes in `index.css` and registered as Tailwind theme animations.
 
 ## Locale

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,9 +47,9 @@ Danish vacation day planner — client-side React app with no backend.
 src/
 ├── components/
 │   ├── ui/                # shadcn components (accordion, alert-dialog, button, card, collapsible, input, label, popover, scroll-area, select, switch, tooltip)
-│   ├── App.tsx            # Root: VacationProvider + TooltipProvider + 2-column layout
+│   ├── App.tsx            # Root: VacationProvider + TooltipProvider + top config bar + responsive layout (sidebar on desktop, drawer on mobile)
 │   ├── HelpIcon.tsx       # Reusable "?" popover icon (click-to-open, click-outside-to-close) using lucide-react CircleHelp
-│   ├── ConfigPane.tsx     # Left pane: settings, holiday toggles (accordion by year), data management (reset)
+│   ├── ConfigPane.tsx     # Exports TopConfigBar (start date + initial days) and SidebarConfig (settings, holidays, data cards)
 │   ├── CalendarView.tsx   # Right pane: scrollable grid of months based on visibleYears, year separators
 │   ├── CalendarMonth.tsx  # Single month: header with ferieår balances + 7-col day grid (Mon–Sun)
 │   └── CalendarDay.tsx    # Day cell: colored circle (no tooltips)
@@ -132,7 +132,9 @@ Balances are computed per **ferieår** (vacation year). Ferieår N runs Sep 1 Ye
 
 ## Key Behaviors
 
-- All 4 ConfigPane cards are collapsible with a chevron icon in the header. Click the header to toggle collapse/expand. Default states: desktop (lg+) all expanded, mobile only first card ("Optjent ferie") expanded.
+- The top config bar (start date + initial vacation days) is always visible at the top of the page above the explanatory text, in a horizontal layout. The label "Optjente feriedage ved startdato" wraps if needed.
+- On desktop (lg+): the sidebar config cards (Indstillinger, Helligdage, Data) are always visible in the left sidebar. Config cards are not collapsible.
+- On mobile: a circular settings icon button (lucide-react `Settings`) appears to the left of the top config bar. Clicking it opens a slide-in drawer from the left containing the sidebar config cards, overlaid on a semi-dark backdrop (`bg-black/50`). Body scroll is locked when the drawer is open (`overflow: hidden` on body + `overscroll-contain` on drawer panel). Drawer auto-closes when resizing to desktop. Clicking the overlay closes the drawer.
 - Each config field in the settings card has a `HelpIcon` (CircleHelp from lucide-react) placed to the right of the input element. Click opens a Popover with a Danish description; click outside dismisses (touch-friendly, no hover required).
 - Dates before `startDate` are disabled and not selectable (status `before-start`)
 - Month headers show ferieår balances with format "YY/(YY+1): X.XX" (e.g., "25/26: 3.40"). Year label is gray, balance is green. For months Jan-Aug only the active ferieår is shown on the left. For Sep-Dec both ferieår are shown (ending year on left, new year on right).
@@ -152,7 +154,8 @@ Balances are computed per **ferieår** (vacation year). Ferieår N runs Sep 1 Ye
 - Context functions (`toggleDate`, `toggleHoliday`, `initDefaults`, `addHoliday`, `resetState`) have stable references (React Compiler handles this automatically)
 - Current year accordion is expanded by default; other years are collapsed
 - Users can add custom holidays via a "Tilføj helligdag" button (opens Popover with name field and native date picker) at the top of the Helligdage card content
-- Number inputs (Feriedage ved start, Ekstra feriedage, Forskudsferie) use `DeferredNumberInput` — local state while typing, commits to global state on blur/Enter. This avoids recomputing `dayStatuses` on every keystroke. All are clamped to 0–99.
+- Number inputs (Optjente feriedage ved startdato, Ekstra feriedage, Forskudsferie) use `DeferredNumberInput` — local state while typing, commits to global state on blur/Enter. This avoids recomputing `dayStatuses` on every keystroke. All are clamped to 0–99.
+- Drawer animations (`drawer-slide-in`, `drawer-overlay-in`) are defined as CSS keyframes in `index.css` and registered as Tailwind theme animations.
 
 ## Locale
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -77,7 +77,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3242,7 +3241,6 @@
       "integrity": "sha512-ne4A0IpG3+2ETuREInjPNhUGis1SFjv1d5asp8MzEAGtOZeTeHVDOYqOgqfhvseqg/iXty2hjBf1zAOb7RNiNw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -3253,7 +3251,6 @@
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3264,7 +3261,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3314,7 +3310,6 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -3677,7 +3672,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3815,7 +3809,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4116,7 +4109,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5147,7 +5139,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5209,7 +5200,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5219,7 +5209,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -5590,7 +5579,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -5720,7 +5708,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -5937,7 +5924,6 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -26,15 +26,15 @@ function AppContent() {
   return (
     <>
       <div className="min-h-screen bg-background text-foreground">
-        <TopConfigBar onOpenDrawer={!isDesktop ? () => setDrawerOpen(true) : undefined} />
-        <p className="text-sm text-muted-foreground text-center max-w-6xl mx-auto px-4 pt-4">
-          Tryk på datoerne i kalenderen for at vælge dine feriedage.
-        </p>
         <div className="flex flex-col lg:flex-row">
           <div className="hidden lg:block">
             <SidebarConfig />
           </div>
           <div className="flex-1 flex flex-col lg:items-center">
+            <TopConfigBar onOpenDrawer={!isDesktop ? () => setDrawerOpen(true) : undefined} />
+            <p className="text-sm text-muted-foreground text-center max-w-6xl w-full px-4 pt-4">
+              Tryk på datoerne i kalenderen for at vælge dine feriedage.
+            </p>
             <CalendarView />
           </div>
         </div>

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -30,9 +30,9 @@ function AppContent() {
           <div className="hidden lg:block">
             <SidebarConfig />
           </div>
-          <div className="flex-1 flex flex-col lg:items-center">
+          <div className="flex-1 flex flex-col lg:items-center gap-4 pt-4">
             <TopConfigBar onOpenDrawer={!isDesktop ? () => setDrawerOpen(true) : undefined} />
-            <p className="text-sm text-muted-foreground text-center max-w-6xl w-full px-4 pt-4">
+            <p className="text-sm text-muted-foreground text-center max-w-6xl w-full px-4">
               Tryk på datoerne i kalenderen for at vælge dine feriedage.
             </p>
             <CalendarView />

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,23 +1,68 @@
+import { useState, useEffect } from 'react';
 import { VacationProvider } from '@/context/VacationContext';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { Toaster } from '@/components/ui/sonner';
-import { ConfigPane } from './ConfigPane';
+import { TopConfigBar, SidebarConfig } from './ConfigPane';
 import { CalendarView } from './CalendarView';
+import { useMediaQuery } from '@/hooks/useMediaQuery';
+
+function AppContent() {
+  const [drawerOpen, setDrawerOpen] = useState(false);
+  const isDesktop = useMediaQuery('(min-width: 1024px)');
+
+  // Lock body scroll when drawer is open
+  useEffect(() => {
+    if (drawerOpen && !isDesktop) {
+      document.body.style.overflow = 'hidden';
+      return () => { document.body.style.overflow = ''; };
+    }
+  }, [drawerOpen, isDesktop]);
+
+  // Close drawer when switching to desktop
+  useEffect(() => {
+    if (isDesktop) setDrawerOpen(false);
+  }, [isDesktop]);
+
+  return (
+    <>
+      <div className="min-h-screen bg-background text-foreground">
+        <TopConfigBar onOpenDrawer={!isDesktop ? () => setDrawerOpen(true) : undefined} />
+        <p className="text-sm text-muted-foreground text-center max-w-6xl mx-auto px-4 pt-4">
+          Tryk på datoerne i kalenderen for at vælge dine feriedage.
+        </p>
+        <div className="flex flex-col lg:flex-row">
+          <div className="hidden lg:block">
+            <SidebarConfig />
+          </div>
+          <div className="flex-1 flex flex-col lg:items-center">
+            <CalendarView />
+          </div>
+        </div>
+      </div>
+
+      {/* Mobile drawer overlay */}
+      {drawerOpen && !isDesktop && (
+        <div className="fixed inset-0 z-50">
+          <div
+            className="absolute inset-0 bg-black/50 animate-drawer-overlay-in"
+            onClick={() => setDrawerOpen(false)}
+          />
+          <div className="absolute inset-y-0 left-0 w-80 max-w-[85vw] bg-background overflow-y-auto overscroll-contain shadow-xl animate-drawer-slide-in">
+            <SidebarConfig />
+          </div>
+        </div>
+      )}
+
+      <Toaster position="bottom-center" />
+    </>
+  );
+}
 
 export default function App() {
   return (
     <VacationProvider>
       <TooltipProvider delayDuration={200}>
-        <div className="flex flex-col lg:flex-row min-h-screen bg-background text-foreground">
-          <ConfigPane />
-          <div className="flex-1 flex flex-col lg:items-center">
-            <p className="text-sm text-muted-foreground text-center max-w-6xl px-4 pt-4 lg:pt-6">
-              Tryk på datoerne i kalenderen for at vælge dine feriedage.
-            </p>
-            <CalendarView />
-          </div>
-        </div>
-        <Toaster position="bottom-center" />
+        <AppContent />
       </TooltipProvider>
     </VacationProvider>
   );

--- a/src/components/CalendarView.tsx
+++ b/src/components/CalendarView.tsx
@@ -60,7 +60,7 @@ function YearSeparator({ year }: { year: number }) {
 
 function YearHeader({ year }: { year: number }) {
   return (
-    <div className="col-span-full pl-2 pt-2">
+    <div className="col-span-full pl-2">
       <h2 className="text-xl font-bold">{year}</h2>
     </div>
   );
@@ -71,7 +71,7 @@ export function CalendarView() {
   const months = generateMonths(visibleYears);
 
   return (
-    <div ref={calendarRef} className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 p-4 max-w-6xl">
+    <div ref={calendarRef} className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 px-4 pb-4 max-w-6xl">
       {months.map((m) => {
         const isJanuary = m.getMonth() === 0;
         const isDecember = m.getMonth() === 11;

--- a/src/components/ConfigPane.tsx
+++ b/src/components/ConfigPane.tsx
@@ -89,12 +89,12 @@ export function TopConfigBar({ onOpenDrawer }: { onOpenDrawer?: () => void }) {
   }, [defaults, initDefaults, state.holidays.length]);
 
   return (
-    <div className="px-4 pt-4 max-w-6xl w-full">
+    <div className="px-4 max-w-6xl w-full">
       {onOpenDrawer && (
         <Button
           variant="outline"
           size="icon"
-          className="rounded-full shrink-0 mb-2"
+          className="rounded-full shrink-0 mb-4"
           onClick={onOpenDrawer}
         >
           <Settings className="size-5" />

--- a/src/components/ConfigPane.tsx
+++ b/src/components/ConfigPane.tsx
@@ -100,7 +100,7 @@ export function TopConfigBar({ onOpenDrawer }: { onOpenDrawer?: () => void }) {
           <Settings className="size-5" />
         </Button>
       )}
-      <div className="flex items-end gap-2 max-w-lg">
+      <div className="flex items-end gap-2 max-w-lg mx-auto">
         <div className="flex-1 min-w-0 space-y-1">
           <Label htmlFor="initialDays">Optjente feriedage</Label>
           <div className="flex gap-2 items-center">

--- a/src/components/ConfigPane.tsx
+++ b/src/components/ConfigPane.tsx
@@ -1,10 +1,8 @@
 import { useEffect, useRef, useState, type ComponentProps } from 'react';
 import { useVacation, defaultState } from '@/context/VacationContext';
 import { useDefaults } from '@/hooks/useHolidays';
-import { useMediaQuery } from '@/hooks/useMediaQuery';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { Collapsible, CollapsibleContent } from '@/components/ui/collapsible';
-import { ChevronDownIcon, Download, PlusIcon, Trash2, Upload } from 'lucide-react';
+import { Download, PlusIcon, Settings, Trash2, Upload } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -73,7 +71,6 @@ import { format } from 'date-fns';
 import { da } from 'date-fns/locale';
 import type { VacationState } from '@/types';
 import { HelpIcon } from '@/components/HelpIcon';
-import { cn } from '@/lib/utils';
 
 
 const MONTH_NAMES = [
@@ -81,8 +78,8 @@ const MONTH_NAMES = [
   'Juli', 'August', 'September', 'Oktober', 'November', 'December',
 ];
 
-export function ConfigPane() {
-  const { state, setState, toggleHoliday, initDefaults, addHoliday, resetState, setHighlightedDate, visibleYears } = useVacation();
+export function TopConfigBar({ onOpenDrawer }: { onOpenDrawer?: () => void }) {
+  const { state, setState, initDefaults } = useVacation();
   const defaults = useDefaults();
 
   useEffect(() => {
@@ -90,6 +87,61 @@ export function ConfigPane() {
       initDefaults(defaults.holidays, defaults.extraHoliday.defaultMonth, defaults.extraHoliday.defaultCount, defaults.advanceDays, defaults.maxTransferDays);
     }
   }, [defaults, initDefaults, state.holidays.length]);
+
+  return (
+    <div className="flex items-end gap-3 px-4 pt-4">
+      {onOpenDrawer && (
+        <Button
+          variant="outline"
+          size="icon"
+          className="rounded-full shrink-0"
+          onClick={onOpenDrawer}
+        >
+          <Settings className="size-5" />
+        </Button>
+      )}
+      <div className="flex flex-wrap gap-x-6 gap-y-3 items-end flex-1">
+        <div className="space-y-1 min-w-48">
+          <Label htmlFor="startDate">Startdato</Label>
+          <div className="flex gap-2 items-center">
+            <Input
+              id="startDate"
+              type="date"
+              value={state.startDate}
+              className="flex-1"
+              onChange={(e) =>
+                setState((prev) => ({ ...prev, startDate: e.target.value }))
+              }
+            />
+            <HelpIcon text="Første dag hvor ferieplanen starter. Dage før denne dato kan ikke vælges." />
+          </div>
+        </div>
+        <div className="space-y-1 min-w-48">
+          <Label htmlFor="initialDays">Optjente feriedage ved startdato</Label>
+          <div className="flex gap-2 items-center">
+            <DeferredNumberInput
+              id="initialDays"
+              min={0}
+              max={99}
+              className="flex-1"
+              value={state.initialVacationDays}
+              onCommit={(v) =>
+                setState((prev) => ({
+                  ...prev,
+                  initialVacationDays: v,
+                }))
+              }
+            />
+            <HelpIcon text="Antal feriedage du allerede har optjent ved startdatoen." />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function SidebarConfig() {
+  const { state, setState, toggleHoliday, addHoliday, resetState, setHighlightedDate, visibleYears } = useVacation();
 
   const yearSet = new Set(visibleYears.map(String));
   const holidaysByYear: Record<string, typeof state.holidays> = {};
@@ -106,26 +158,6 @@ export function ConfigPane() {
   const [pendingImport, setPendingImport] = useState<VacationState | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
-  // Collapsible card states - responsive defaults
-  const isDesktop = useMediaQuery('(min-width: 1024px)');
-  const initializedRef = useRef(false);
-  const [optjentFerieOpen, setOptjentFerieOpen] = useState(true);
-  const [indstillingerOpen, setIndstillingerOpen] = useState(true);
-  const [helligdageOpen, setHelligdageOpen] = useState(true);
-  const [dataOpen, setDataOpen] = useState(true);
-
-  useEffect(() => {
-    if (!initializedRef.current) {
-      initializedRef.current = true;
-      if (!isDesktop) {
-        // On mobile: only first card expanded
-        setIndstillingerOpen(false);
-        setHelligdageOpen(false);
-        setDataOpen(false);
-      }
-    }
-  }, [isDesktop]);
-
   function handleAddHoliday() {
     if (!newHolidayDate || !newHolidayName.trim()) return;
     addHoliday(newHolidayDate, newHolidayName.trim());
@@ -137,341 +169,267 @@ export function ConfigPane() {
   return (
     <div className="space-y-4 p-4 w-full lg:w-80 shrink-0">
       <Card>
-        <Collapsible open={optjentFerieOpen} onOpenChange={setOptjentFerieOpen}>
-          <CardHeader
-            onClick={() => setOptjentFerieOpen(!optjentFerieOpen)}
-            className="flex flex-row items-center justify-between select-none transition-colors cursor-pointer hover:bg-muted/50"
-          >
-            <CardTitle>Optjent ferie</CardTitle>
-            <ChevronDownIcon className={cn("size-4 text-muted-foreground shrink-0 transition-transform duration-200", optjentFerieOpen && "rotate-180")} />
-          </CardHeader>
-          <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
-            <CardContent className="space-y-4 pt-4">
-              <div className="space-y-1">
-                <Label htmlFor="startDate">Startdato</Label>
-                <div className="flex gap-2 items-center">
-                  <Input
-                    id="startDate"
-                    type="date"
-                    value={state.startDate}
-                    className="flex-1"
-                    onChange={(e) =>
-                      setState((prev) => ({ ...prev, startDate: e.target.value }))
-                    }
-                  />
-                  <HelpIcon text="Første dag hvor ferieplanen starter. Dage før denne dato kan ikke vælges." />
-                </div>
+        <CardHeader>
+          <CardTitle>Indstillinger</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="space-y-1">
+            <div className="flex gap-2 items-end">
+              <div className="grow-[3] basis-0 min-w-0 space-y-1">
+                <Label>Ekstra feriedage</Label>
+                <DeferredNumberInput
+                  min={0}
+                  max={99}
+                  value={state.extraDaysCount}
+                  onCommit={(v) =>
+                    setState((prev) => ({ ...prev, extraDaysCount: v }))
+                  }
+                />
               </div>
-              <div className="space-y-1">
-                <Label htmlFor="initialDays">Feriedage ved start</Label>
-                <div className="flex gap-2 items-center">
-                  <DeferredNumberInput
-                    id="initialDays"
-                    min={0}
-                    max={99}
-                    className="flex-1"
-                    value={state.initialVacationDays}
-                    onCommit={(v) =>
-                      setState((prev) => ({
-                        ...prev,
-                        initialVacationDays: v,
-                      }))
-                    }
-                  />
-                  <HelpIcon text="Antal feriedage du allerede har optjent ved startdatoen." />
-                </div>
-              </div>
-            </CardContent>
-          </CollapsibleContent>
-        </Collapsible>
-      </Card>
-
-      <Card>
-        <Collapsible open={indstillingerOpen} onOpenChange={setIndstillingerOpen}>
-          <CardHeader
-            onClick={() => setIndstillingerOpen(!indstillingerOpen)}
-            className="flex flex-row items-center justify-between select-none transition-colors cursor-pointer hover:bg-muted/50"
-          >
-            <CardTitle>Indstillinger</CardTitle>
-            <ChevronDownIcon className={cn("size-4 text-muted-foreground shrink-0 transition-transform duration-200", indstillingerOpen && "rotate-180")} />
-          </CardHeader>
-          <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
-            <CardContent className="space-y-4 pt-4">
-              <div className="space-y-1">
-                <div className="flex gap-2 items-end">
-                  <div className="grow-[3] basis-0 min-w-0 space-y-1">
-                    <Label>Ekstra feriedage</Label>
-                    <DeferredNumberInput
-                      min={0}
-                      max={99}
-                      value={state.extraDaysCount}
-                      onCommit={(v) =>
-                        setState((prev) => ({ ...prev, extraDaysCount: v }))
-                      }
-                    />
-                  </div>
-                  <div className="grow-[2] basis-0 min-w-0 space-y-1">
-                    <Label>Tildeles i</Label>
-                    <Select
-                      value={String(state.extraDaysMonth)}
-                      onValueChange={(v) =>
-                        setState((prev) => ({ ...prev, extraDaysMonth: Number(v) }))
-                      }
-                    >
-                      <SelectTrigger className="w-full">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        {MONTH_NAMES.map((name, i) => (
-                          <SelectItem key={i + 1} value={String(i + 1)}>
-                            {name}
-                          </SelectItem>
-                        ))}
-                      </SelectContent>
-                    </Select>
-                  </div>
-                  <div className="h-9 flex items-center">
-                    <HelpIcon text="Ekstra feriedage (f.eks. 6. ferieuge) og hvilken måned de tildeles." />
-                  </div>
-                </div>
-              </div>
-              <div className="space-y-1">
-                <Label htmlFor="advanceDays">Forskudsferie</Label>
-                <div className="flex gap-2 items-center">
-                  <DeferredNumberInput
-                    id="advanceDays"
-                    min={0}
-                    max={99}
-                    className="flex-1"
-                    value={state.advanceDays}
-                    onCommit={(v) =>
-                      setState((prev) => ({
-                        ...prev,
-                        advanceDays: v,
-                      }))
-                    }
-                  />
-                  <HelpIcon text="Antal dage du må låne på forskud, før de er optjent." />
-                </div>
-              </div>
-              <div className="space-y-1">
-                <Label htmlFor="maxTransferDays">Overførbare feriedage</Label>
-                <div className="flex gap-2 items-center">
-                  <DeferredNumberInput
-                    id="maxTransferDays"
-                    min={0}
-                    max={99}
-                    className="flex-1"
-                    value={state.maxTransferDays}
-                    onCommit={(v) =>
-                      setState((prev) => ({
-                        ...prev,
-                        maxTransferDays: v,
-                      }))
-                    }
-                  />
-                  <HelpIcon text="Maks antal ubrugte feriedage der kan overføres til næste ferieår." />
-                </div>
-              </div>
-            </CardContent>
-          </CollapsibleContent>
-        </Collapsible>
-      </Card>
-
-      <Card>
-        <Collapsible open={helligdageOpen} onOpenChange={setHelligdageOpen}>
-          <CardHeader
-            onClick={() => setHelligdageOpen(!helligdageOpen)}
-            className="flex flex-row items-center justify-between select-none transition-colors cursor-pointer hover:bg-muted/50"
-          >
-            <CardTitle>Helligdage</CardTitle>
-            <ChevronDownIcon className={cn("size-4 text-muted-foreground shrink-0 transition-transform duration-200", helligdageOpen && "rotate-180")} />
-          </CardHeader>
-          <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
-            <CardContent className="p-0">
-              <div className="px-6 pt-4 pb-3">
-                <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
-                  <PopoverTrigger asChild>
-                    <Button variant="outline" size="sm" className="w-full">
-                      <PlusIcon className="size-4 mr-2" />
-                      Tilføj helligdag
-                    </Button>
-                  </PopoverTrigger>
-                  <PopoverContent className="w-64 space-y-3">
-                    <div className="space-y-1">
-                      <Label htmlFor="newHolidayName">Navn</Label>
-                      <Input
-                        id="newHolidayName"
-                        value={newHolidayName}
-                        onChange={(e) => setNewHolidayName(e.target.value)}
-                        placeholder="f.eks. Grundlovsdag"
-                      />
-                    </div>
-                    <div className="space-y-1">
-                      <Label htmlFor="newHolidayDate">Dato</Label>
-                      <Input
-                        id="newHolidayDate"
-                        type="date"
-                        value={newHolidayDate}
-                        onChange={(e) => setNewHolidayDate(e.target.value)}
-                      />
-                    </div>
-                    <Button size="sm" className="w-full" onClick={handleAddHoliday} disabled={!newHolidayDate || !newHolidayName.trim()}>
-                      Tilføj
-                    </Button>
-                  </PopoverContent>
-                </Popover>
-              </div>
-              <Accordion type="multiple" defaultValue={[String(new Date().getFullYear())]}>
-                {Object.entries(holidaysByYear).map(([year, yearHolidays]) => (
-                  <AccordionItem key={year} value={year}>
-                    <AccordionTrigger className="px-6 py-3 text-sm">
-                      {year}
-                    </AccordionTrigger>
-                    <AccordionContent className="px-6 space-y-2 pb-3">
-                      {yearHolidays.map((h) => (
-                        <Tooltip key={h.date}>
-                          <TooltipTrigger asChild>
-                            <div
-                              className="flex items-center justify-between text-sm cursor-pointer select-none hover:bg-muted rounded-md px-1 -mx-1"
-                              onMouseEnter={() => setHighlightedDate(h.date)}
-                              onMouseLeave={() => setHighlightedDate(null)}
-                              onClick={() => toggleHoliday(h.date)}
-                            >
-                              <span>{h.name}</span>
-                              <div onClick={(e) => e.stopPropagation()}>
-                                <Switch
-                                  checked={!!state.enabledHolidays[h.date]}
-                                  onCheckedChange={() => toggleHoliday(h.date)}
-                                />
-                              </div>
-                            </div>
-                          </TooltipTrigger>
-                          <TooltipContent side="right" className="text-xs">
-                            {format(new Date(h.date + 'T00:00:00'), 'EEEE d. MMMM yyyy', { locale: da })}
-                          </TooltipContent>
-                        </Tooltip>
-                      ))}
-                    </AccordionContent>
-                  </AccordionItem>
-                ))}
-              </Accordion>
-            </CardContent>
-          </CollapsibleContent>
-        </Collapsible>
-      </Card>
-
-      <Card>
-        <Collapsible open={dataOpen} onOpenChange={setDataOpen}>
-          <CardHeader
-            onClick={() => setDataOpen(!dataOpen)}
-            className="flex flex-row items-center justify-between select-none transition-colors cursor-pointer hover:bg-muted/50"
-          >
-            <CardTitle>Data</CardTitle>
-            <ChevronDownIcon className={cn("size-4 text-muted-foreground shrink-0 transition-transform duration-200", dataOpen && "rotate-180")} />
-          </CardHeader>
-          <CollapsibleContent className="overflow-hidden data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down">
-            <CardContent className="pt-4">
-              <div className="flex gap-2 justify-center">
-                <Button
-                  variant="outline"
-                  className="flex-1 h-auto flex-col gap-1 py-3 cursor-pointer"
-                  onClick={() => {
-                    const blob = new Blob([JSON.stringify(state, null, 2)], { type: 'application/json' });
-                    const url = URL.createObjectURL(blob);
-                    const a = document.createElement('a');
-                    a.href = url;
-                    a.download = 'ferieplan.json';
-                    a.click();
-                    URL.revokeObjectURL(url);
-                  }}
+              <div className="grow-[2] basis-0 min-w-0 space-y-1">
+                <Label>Tildeles i</Label>
+                <Select
+                  value={String(state.extraDaysMonth)}
+                  onValueChange={(v) =>
+                    setState((prev) => ({ ...prev, extraDaysMonth: Number(v) }))
+                  }
                 >
-                  <Download className="size-5" />
-                  <span className="text-xs">Gem</span>
-                </Button>
-                <Button
-                  variant="outline"
-                  className="flex-1 h-auto flex-col gap-1 py-3 cursor-pointer"
-                  onClick={() => fileInputRef.current?.click()}
-                >
-                  <Upload className="size-5" />
-                  <span className="text-xs">Indlæs</span>
-                </Button>
-                <AlertDialog>
-                  <AlertDialogTrigger asChild>
-                    <Button
-                      variant="outline"
-                      className="flex-1 h-auto flex-col gap-1 py-3 cursor-pointer hover:bg-red-100 hover:text-red-700 hover:border-red-300"
-                    >
-                      <Trash2 className="size-5" />
-                      <span className="text-xs">Ryd</span>
-                    </Button>
-                  </AlertDialogTrigger>
-                  <AlertDialogContent>
-                    <AlertDialogHeader>
-                      <AlertDialogTitle>Er du sikker?</AlertDialogTitle>
-                      <AlertDialogDescription>
-                        Dette sletter alle dine indstillinger, valgte feriedage og gemte data. Handlingen kan ikke fortrydes.
-                      </AlertDialogDescription>
-                    </AlertDialogHeader>
-                    <AlertDialogFooter>
-                      <AlertDialogCancel>Annuller</AlertDialogCancel>
-                      <AlertDialogAction
-                        className="bg-red-600 hover:bg-red-700"
-                        onClick={resetState}
-                      >
-                        Ryd alting
-                      </AlertDialogAction>
-                    </AlertDialogFooter>
-                  </AlertDialogContent>
-                </AlertDialog>
+                  <SelectTrigger className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {MONTH_NAMES.map((name, i) => (
+                      <SelectItem key={i + 1} value={String(i + 1)}>
+                        {name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
-              <input
-                ref={fileInputRef}
-                type="file"
-                accept=".json"
-                className="hidden"
-                onChange={(e) => {
-                  const file = e.target.files?.[0];
-                  if (!file) return;
-                  const reader = new FileReader();
-                  reader.onload = () => {
-                    try {
-                      const data = { ...defaultState, ...JSON.parse(reader.result as string) };
-                      setPendingImport(data);
-                      setImportDialogOpen(true);
-                    } catch {
-                      alert('Ugyldig JSON-fil.');
-                    }
-                  };
-                  reader.readAsText(file);
-                  e.target.value = '';
-                }}
+              <div className="h-9 flex items-center">
+                <HelpIcon text="Ekstra feriedage (f.eks. 6. ferieuge) og hvilken måned de tildeles." />
+              </div>
+            </div>
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="advanceDays">Forskudsferie</Label>
+            <div className="flex gap-2 items-center">
+              <DeferredNumberInput
+                id="advanceDays"
+                min={0}
+                max={99}
+                className="flex-1"
+                value={state.advanceDays}
+                onCommit={(v) =>
+                  setState((prev) => ({
+                    ...prev,
+                    advanceDays: v,
+                  }))
+                }
               />
-              <AlertDialog open={importDialogOpen} onOpenChange={setImportDialogOpen}>
-                <AlertDialogContent>
-                  <AlertDialogHeader>
-                    <AlertDialogTitle>Indlæs plan?</AlertDialogTitle>
-                    <AlertDialogDescription>
-                      Dette erstatter alle dine nuværende indstillinger og valgte feriedage med data fra filen. Handlingen kan ikke fortrydes.
-                    </AlertDialogDescription>
-                  </AlertDialogHeader>
-                  <AlertDialogFooter>
-                    <AlertDialogCancel onClick={() => setPendingImport(null)}>Annuller</AlertDialogCancel>
-                    <AlertDialogAction onClick={() => {
-                      if (pendingImport) {
-                        setState(pendingImport);
-                        setPendingImport(null);
-                      }
-                    }}>
-                      Indlæs
-                    </AlertDialogAction>
-                  </AlertDialogFooter>
-                </AlertDialogContent>
-              </AlertDialog>
-            </CardContent>
-          </CollapsibleContent>
-        </Collapsible>
+              <HelpIcon text="Antal dage du må låne på forskud, før de er optjent." />
+            </div>
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="maxTransferDays">Overførbare feriedage</Label>
+            <div className="flex gap-2 items-center">
+              <DeferredNumberInput
+                id="maxTransferDays"
+                min={0}
+                max={99}
+                className="flex-1"
+                value={state.maxTransferDays}
+                onCommit={(v) =>
+                  setState((prev) => ({
+                    ...prev,
+                    maxTransferDays: v,
+                  }))
+                }
+              />
+              <HelpIcon text="Maks antal ubrugte feriedage der kan overføres til næste ferieår." />
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Helligdage</CardTitle>
+        </CardHeader>
+        <CardContent className="p-0">
+          <div className="px-6 pb-3">
+            <Popover open={popoverOpen} onOpenChange={setPopoverOpen}>
+              <PopoverTrigger asChild>
+                <Button variant="outline" size="sm" className="w-full">
+                  <PlusIcon className="size-4 mr-2" />
+                  Tilføj helligdag
+                </Button>
+              </PopoverTrigger>
+              <PopoverContent className="w-64 space-y-3">
+                <div className="space-y-1">
+                  <Label htmlFor="newHolidayName">Navn</Label>
+                  <Input
+                    id="newHolidayName"
+                    value={newHolidayName}
+                    onChange={(e) => setNewHolidayName(e.target.value)}
+                    placeholder="f.eks. Grundlovsdag"
+                  />
+                </div>
+                <div className="space-y-1">
+                  <Label htmlFor="newHolidayDate">Dato</Label>
+                  <Input
+                    id="newHolidayDate"
+                    type="date"
+                    value={newHolidayDate}
+                    onChange={(e) => setNewHolidayDate(e.target.value)}
+                  />
+                </div>
+                <Button size="sm" className="w-full" onClick={handleAddHoliday} disabled={!newHolidayDate || !newHolidayName.trim()}>
+                  Tilføj
+                </Button>
+              </PopoverContent>
+            </Popover>
+          </div>
+          <Accordion type="multiple" defaultValue={[String(new Date().getFullYear())]}>
+            {Object.entries(holidaysByYear).map(([year, yearHolidays]) => (
+              <AccordionItem key={year} value={year}>
+                <AccordionTrigger className="px-6 py-3 text-sm">
+                  {year}
+                </AccordionTrigger>
+                <AccordionContent className="px-6 space-y-2 pb-3">
+                  {yearHolidays.map((h) => (
+                    <Tooltip key={h.date}>
+                      <TooltipTrigger asChild>
+                        <div
+                          className="flex items-center justify-between text-sm cursor-pointer select-none hover:bg-muted rounded-md px-1 -mx-1"
+                          onMouseEnter={() => setHighlightedDate(h.date)}
+                          onMouseLeave={() => setHighlightedDate(null)}
+                          onClick={() => toggleHoliday(h.date)}
+                        >
+                          <span>{h.name}</span>
+                          <div onClick={(e) => e.stopPropagation()}>
+                            <Switch
+                              checked={!!state.enabledHolidays[h.date]}
+                              onCheckedChange={() => toggleHoliday(h.date)}
+                            />
+                          </div>
+                        </div>
+                      </TooltipTrigger>
+                      <TooltipContent side="right" className="text-xs">
+                        {format(new Date(h.date + 'T00:00:00'), 'EEEE d. MMMM yyyy', { locale: da })}
+                      </TooltipContent>
+                    </Tooltip>
+                  ))}
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Data</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex gap-2 justify-center">
+            <Button
+              variant="outline"
+              className="flex-1 h-auto flex-col gap-1 py-3 cursor-pointer"
+              onClick={() => {
+                const blob = new Blob([JSON.stringify(state, null, 2)], { type: 'application/json' });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = 'ferieplan.json';
+                a.click();
+                URL.revokeObjectURL(url);
+              }}
+            >
+              <Download className="size-5" />
+              <span className="text-xs">Gem</span>
+            </Button>
+            <Button
+              variant="outline"
+              className="flex-1 h-auto flex-col gap-1 py-3 cursor-pointer"
+              onClick={() => fileInputRef.current?.click()}
+            >
+              <Upload className="size-5" />
+              <span className="text-xs">Indlæs</span>
+            </Button>
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button
+                  variant="outline"
+                  className="flex-1 h-auto flex-col gap-1 py-3 cursor-pointer hover:bg-red-100 hover:text-red-700 hover:border-red-300"
+                >
+                  <Trash2 className="size-5" />
+                  <span className="text-xs">Ryd</span>
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Er du sikker?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    Dette sletter alle dine indstillinger, valgte feriedage og gemte data. Handlingen kan ikke fortrydes.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Annuller</AlertDialogCancel>
+                  <AlertDialogAction
+                    className="bg-red-600 hover:bg-red-700"
+                    onClick={resetState}
+                  >
+                    Ryd alting
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".json"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (!file) return;
+              const reader = new FileReader();
+              reader.onload = () => {
+                try {
+                  const data = { ...defaultState, ...JSON.parse(reader.result as string) };
+                  setPendingImport(data);
+                  setImportDialogOpen(true);
+                } catch {
+                  alert('Ugyldig JSON-fil.');
+                }
+              };
+              reader.readAsText(file);
+              e.target.value = '';
+            }}
+          />
+          <AlertDialog open={importDialogOpen} onOpenChange={setImportDialogOpen}>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Indlæs plan?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Dette erstatter alle dine nuværende indstillinger og valgte feriedage med data fra filen. Handlingen kan ikke fortrydes.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel onClick={() => setPendingImport(null)}>Annuller</AlertDialogCancel>
+                <AlertDialogAction onClick={() => {
+                  if (pendingImport) {
+                    setState(pendingImport);
+                    setPendingImport(null);
+                  }
+                }}>
+                  Indlæs
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </CardContent>
       </Card>
     </div>
   );

--- a/src/components/ConfigPane.tsx
+++ b/src/components/ConfigPane.tsx
@@ -89,7 +89,7 @@ export function TopConfigBar({ onOpenDrawer }: { onOpenDrawer?: () => void }) {
   }, [defaults, initDefaults, state.holidays.length]);
 
   return (
-    <div className="flex items-end gap-3 px-4 pt-4">
+    <div className="flex items-end gap-2 px-4 pt-4 max-w-6xl w-full">
       {onOpenDrawer && (
         <Button
           variant="outline"
@@ -100,40 +100,38 @@ export function TopConfigBar({ onOpenDrawer }: { onOpenDrawer?: () => void }) {
           <Settings className="size-5" />
         </Button>
       )}
-      <div className="flex flex-wrap gap-x-6 gap-y-3 items-end flex-1">
-        <div className="space-y-1 min-w-48">
-          <Label htmlFor="startDate">Startdato</Label>
-          <div className="flex gap-2 items-center">
-            <Input
-              id="startDate"
-              type="date"
-              value={state.startDate}
-              className="flex-1"
-              onChange={(e) =>
-                setState((prev) => ({ ...prev, startDate: e.target.value }))
-              }
-            />
-            <HelpIcon text="Første dag hvor ferieplanen starter. Dage før denne dato kan ikke vælges." />
-          </div>
+      <div className="flex-1 min-w-0 space-y-1">
+        <Label htmlFor="startDate">Startdato</Label>
+        <div className="flex gap-2 items-center">
+          <Input
+            id="startDate"
+            type="date"
+            value={state.startDate}
+            className="flex-1 min-w-0"
+            onChange={(e) =>
+              setState((prev) => ({ ...prev, startDate: e.target.value }))
+            }
+          />
+          <HelpIcon text="Første dag hvor ferieplanen starter. Dage før denne dato kan ikke vælges." />
         </div>
-        <div className="space-y-1 min-w-48">
-          <Label htmlFor="initialDays">Optjente feriedage ved startdato</Label>
-          <div className="flex gap-2 items-center">
-            <DeferredNumberInput
-              id="initialDays"
-              min={0}
-              max={99}
-              className="flex-1"
-              value={state.initialVacationDays}
-              onCommit={(v) =>
-                setState((prev) => ({
-                  ...prev,
-                  initialVacationDays: v,
-                }))
-              }
-            />
-            <HelpIcon text="Antal feriedage du allerede har optjent ved startdatoen." />
-          </div>
+      </div>
+      <div className="flex-1 min-w-0 space-y-1">
+        <Label htmlFor="initialDays">Optjente feriedage ved startdato</Label>
+        <div className="flex gap-2 items-center">
+          <DeferredNumberInput
+            id="initialDays"
+            min={0}
+            max={99}
+            className="flex-1 min-w-0"
+            value={state.initialVacationDays}
+            onCommit={(v) =>
+              setState((prev) => ({
+                ...prev,
+                initialVacationDays: v,
+              }))
+            }
+          />
+          <HelpIcon text="Antal feriedage du allerede har optjent ved startdatoen." />
         </div>
       </div>
     </div>

--- a/src/components/ConfigPane.tsx
+++ b/src/components/ConfigPane.tsx
@@ -89,49 +89,51 @@ export function TopConfigBar({ onOpenDrawer }: { onOpenDrawer?: () => void }) {
   }, [defaults, initDefaults, state.holidays.length]);
 
   return (
-    <div className="flex items-end gap-2 px-4 pt-4 max-w-6xl w-full">
+    <div className="px-4 pt-4 max-w-6xl w-full">
       {onOpenDrawer && (
         <Button
           variant="outline"
           size="icon"
-          className="rounded-full shrink-0"
+          className="rounded-full shrink-0 mb-2"
           onClick={onOpenDrawer}
         >
           <Settings className="size-5" />
         </Button>
       )}
-      <div className="flex-1 min-w-0 space-y-1">
-        <Label htmlFor="startDate">Startdato</Label>
-        <div className="flex gap-2 items-center">
-          <Input
-            id="startDate"
-            type="date"
-            value={state.startDate}
-            className="flex-1 min-w-0"
-            onChange={(e) =>
-              setState((prev) => ({ ...prev, startDate: e.target.value }))
-            }
-          />
-          <HelpIcon text="Første dag hvor ferieplanen starter. Dage før denne dato kan ikke vælges." />
+      <div className="flex items-end gap-2 max-w-lg">
+        <div className="flex-1 min-w-0 space-y-1">
+          <Label htmlFor="initialDays">Optjente feriedage</Label>
+          <div className="flex gap-2 items-center">
+            <DeferredNumberInput
+              id="initialDays"
+              min={0}
+              max={99}
+              className="flex-1 min-w-0"
+              value={state.initialVacationDays}
+              onCommit={(v) =>
+                setState((prev) => ({
+                  ...prev,
+                  initialVacationDays: v,
+                }))
+              }
+            />
+            <HelpIcon text="Antal feriedage du allerede har optjent ved startdatoen." />
+          </div>
         </div>
-      </div>
-      <div className="flex-1 min-w-0 space-y-1">
-        <Label htmlFor="initialDays">Optjente feriedage ved startdato</Label>
-        <div className="flex gap-2 items-center">
-          <DeferredNumberInput
-            id="initialDays"
-            min={0}
-            max={99}
-            className="flex-1 min-w-0"
-            value={state.initialVacationDays}
-            onCommit={(v) =>
-              setState((prev) => ({
-                ...prev,
-                initialVacationDays: v,
-              }))
-            }
-          />
-          <HelpIcon text="Antal feriedage du allerede har optjent ved startdatoen." />
+        <div className="flex-1 min-w-0 space-y-1">
+          <Label htmlFor="startDate">Fra dato</Label>
+          <div className="flex gap-2 items-center">
+            <Input
+              id="startDate"
+              type="date"
+              value={state.startDate}
+              className="flex-1 min-w-0"
+              onChange={(e) =>
+                setState((prev) => ({ ...prev, startDate: e.target.value }))
+              }
+            />
+            <HelpIcon text="Første dag hvor ferieplanen starter. Dage før denne dato kan ikke vælges." />
+          </div>
         </div>
       </div>
     </div>

--- a/src/index.css
+++ b/src/index.css
@@ -3,7 +3,19 @@
 
 @custom-variant dark (&:is(.dark *));
 
+@keyframes drawer-slide-in {
+  from { transform: translateX(-100%); }
+  to { transform: translateX(0); }
+}
+
+@keyframes drawer-overlay-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
 @theme inline {
+  --animate-drawer-slide-in: drawer-slide-in 0.25s ease-out;
+  --animate-drawer-overlay-in: drawer-overlay-in 0.25s ease-out;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);


### PR DESCRIPTION
## Summary
Refactored the monolithic `ConfigPane` component into two separate, responsive components: `TopConfigBar` (for mobile/top bar) and `SidebarConfig` (for desktop sidebar). Implemented a mobile drawer UI that slides in from the left when the settings button is clicked on smaller screens.

## Key Changes

- **Split ConfigPane into two components:**
  - `TopConfigBar`: Displays start date and initial vacation days in a horizontal layout at the top; includes a Settings button that opens the drawer on mobile
  - `SidebarConfig`: Contains all configuration cards (settings, holidays, data management); displayed as a fixed sidebar on desktop (lg+) and as a slide-in drawer on mobile

- **Removed collapsible card logic:**
  - Eliminated `useMediaQuery` hook usage and responsive collapse state management from the config pane
  - All cards in `SidebarConfig` are now always expanded (no accordion/collapsible behavior)
  - Removed `ChevronDownIcon` and `Collapsible` component imports

- **Implemented mobile drawer UI:**
  - Added drawer state management in `App.tsx` with `drawerOpen` state
  - Drawer slides in from the left with smooth animation on mobile
  - Semi-transparent overlay behind drawer that closes it when clicked
  - Body scroll is locked when drawer is open on mobile
  - Drawer automatically closes when switching to desktop view

- **Updated App.tsx layout:**
  - Changed from simple 2-column flex layout to responsive layout with conditional rendering
  - Desktop (lg+): `SidebarConfig` displayed as hidden sidebar, calendar takes full width
  - Mobile: `TopConfigBar` at top, calendar below, drawer accessible via Settings button
  - Added new CSS animations for drawer slide-in and overlay fade-in effects

- **Updated documentation:**
  - Modified CLAUDE.md to reflect new component structure and responsive behavior

## Implementation Details

- Drawer uses `fixed` positioning with `z-50` to overlay the entire screen
- Animations use custom keyframes (`drawer-slide-in`, `drawer-overlay-in`) with 0.25s ease-out timing
- Mobile drawer has `max-w-[85vw]` constraint to ensure it doesn't exceed screen width
- Settings button only renders on mobile via conditional `onOpenDrawer` prop

https://claude.ai/code/session_01NsQAKWh1JRqHTVmomZDThe